### PR TITLE
Fix: Resolve initial setup and dependency issues

### DIFF
--- a/myshop/settings.py
+++ b/myshop/settings.py
@@ -103,7 +103,12 @@ ASGI_APPLICATION = 'myshop.asgi.application' # Corrected path, assuming asgi.py 
 # Database
 # https://docs.djangoproject.com/en/5.2/ref/settings/#databases
 
-DATABASES = json.loads(config('DATABASES'))
+_databases_config_str = config('DATABASES')
+DATABASES = json.loads(_databases_config_str)
+
+# Ensure the SQLite database path is relative to BASE_DIR
+if DATABASES.get('default', {}).get('ENGINE') == 'django.db.backends.sqlite3':
+    DATABASES['default']['NAME'] = BASE_DIR / 'db.sqlite3'
 
 
 # Password validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,5 @@ Twisted==24.11.0
 txaio==23.1.1
 typing_extensions==4.13.2
 zope.interface==7.2
+python-decouple
+django-jalali-date


### PR DESCRIPTION
- Add missing dependencies `python-decouple` and `django-jalali-date` to `requirements.txt`.
- Modify `myshop/settings.py` to ensure the SQLite database path is correctly constructed relative to `BASE_DIR`, resolving database connection errors during initial migration.